### PR TITLE
Enable longitude west of Chicago and east of India

### DIFF
--- a/source/DataArea.mc
+++ b/source/DataArea.mc
@@ -107,7 +107,7 @@ class DataArea extends Ui.Drawable {
 
 			// Time zone 1 time.
 			var time;
-			if (view.mLocalCityLat != null && view.mLocalCityLat >= -90.0 && view.mLocalCityLat <= 90.0 && view.mLocalCityLon != null && view.mLocalCityLon >= -90.0 && view.mLocalCityLon <= 90.0) {
+			if (view.mLocalCityLat != null && view.mLocalCityLat >= -90.0 && view.mLocalCityLat <= 90.0 && view.mLocalCityLon != null && view.mLocalCityLon >= -180.0 && view.mLocalCityLon <= 180.0) {
 				try {
 					var where = new Position.Location({
 						:latitude  => view.mLocalCityLat,


### PR DESCRIPTION
Longitude go between -180 and +180. See [here](https://en.wikipedia.org/wiki/Geographic_coordinate_system#Latitude_and_longitude)

Currently, [this check](https://github.com/SylvainGa/crystal-face/blob/cf9da496097ab6cade916683746157fc75bc8191/source/DataArea.mc#L110) restricts the longitude to between -90 and +90, so we can only have a second city time east of Chicago and west of India (roughly).

I did test on my watch for the [time in Bangladesh](https://www.timeanddate.com/worldclock/bangladesh/dhaka): entering "Bangladesh,23,**89**" displays the correct time, "Bangladesh,23,**91**"  displays '???'.

Same with the [time in Dallas](https://www.timeanddate.com/worldclock/usa/dallas) ("Dallas,32.78,**-96.8**") vs. [time in Chicago](https://www.timeanddate.com/worldclock/usa/chicago) ("Chicago,41.85,**-87.65**") : 

The Latitude is correct: it runs from -90 to +90

It's my very first push request on Github. I apologise in advance if I haven't done it the correct way.